### PR TITLE
Disable toggling if sliding isn't enabled. 

### DIFF
--- a/library/src/com/slidingmenu/lib/app/SlidingActivityHelper.java
+++ b/library/src/com/slidingmenu/lib/app/SlidingActivityHelper.java
@@ -105,6 +105,9 @@ public class SlidingActivityHelper {
 	}
 
 	public void toggle() {
+
+        if (!mSlidingMenu.isSlidingEnabled()) return;
+
 		if (mSlidingMenu.isBehindShowing()) {
 			showAbove();
 		} else {


### PR DESCRIPTION
Shouldn't allow someone to toggle the menu if sliding isn't enabled (since toggle is essentially a slide).  However, we can explicitly allow someone to show the above or behind views. 

Let me know what you think.
