### PR TITLE
Add flag to onOpened for passing which side was just opened.

### DIFF
--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -530,8 +530,12 @@ public class CustomViewAbove extends ViewGroup {
 			completeScroll();
 			if (isLeftOpen()) {
 				if (mOpenedListener != null)
-					mOpenedListener.onOpened();
+					mOpenedListener.onOpened(SlidingMenu.LEFT);
+			} else if (isRightOpen()) {
+				if (mOpenedListener != null)
+					mOpenedListener.onOpened(SlidingMenu.RIGHT);
 			} else {
+				
 				if (mClosedListener != null)
 					mClosedListener.onClosed();
 			}
@@ -697,7 +701,10 @@ public class CustomViewAbove extends ViewGroup {
 			}
 			if (isLeftOpen()) {
 				if (mOpenedListener != null)
-					mOpenedListener.onOpened();
+					mOpenedListener.onOpened(SlidingMenu.LEFT);
+			} else if (isRightOpen()) {
+				if (mOpenedListener != null)
+					mOpenedListener.onOpened(SlidingMenu.RIGHT);
 			} else {
 				if (mClosedListener != null)
 					mClosedListener.onClosed();

--- a/library/src/com/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/slidingmenu/lib/SlidingMenu.java
@@ -77,7 +77,7 @@ public class SlidingMenu extends RelativeLayout {
 	}
 
 	public interface OnOpenedListener {
-		public void onOpened();
+		public void onOpened(int side);
 	}
 
 	public interface OnCloseListener {


### PR DESCRIPTION
So when using a custom OnOpenedListener, you can figure out which view was just opened.

I'm doing some network I/O for my right view and wanted to hold off on it until the view was opened and figured I'd pass my local modifications across :)
