### PR TITLE
fix the SavedState usage when recovering from a dead activity

### DIFF
--- a/library/src/com/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/slidingmenu/lib/SlidingMenu.java
@@ -389,45 +389,40 @@ public class SlidingMenu extends RelativeLayout {
 		mViewAbove.setOnClosedListener(listener);
 	}
 
-	private static class SavedState extends BaseSavedState {
-		boolean mBehindShowing;
+	public static class SavedState extends BaseSavedState {
+		private final boolean mBehindShowing;
 
-		public SavedState(Parcelable superState) {
+		public SavedState(Parcelable superState, boolean isBehindShowing) {
 			super(superState);
+			mBehindShowing = isBehindShowing;
 		}
 
 		public void writeToParcel(Parcel out, int flags) {
 			super.writeToParcel(out, flags);
-			out.writeBooleanArray(new boolean[]{mBehindShowing});
+			out.writeByte(mBehindShowing ? (byte)1 : 0);
 		}
 
-		/*
-		public static final Parcelable.Creator<SavedState> CREATOR
-		= ParcelableCompat.newCreator(new ParcelableCompatCreatorCallbacks<SavedState>() {
+        public static final Parcelable.Creator<SavedState> CREATOR =
+                new Parcelable.Creator<SavedState>() {
+            public SavedState createFromParcel(Parcel in) {
+                return new SavedState(in);
+            }
 
-			public SavedState createFromParcel(Parcel in, ClassLoader loader) {
-				return new SavedState(in);
-			}
-
-			public SavedState[] newArray(int size) {
-				return new SavedState[size];
-			}
-		});
-
-		SavedState(Parcel in) {
+            public SavedState[] newArray(int size) {
+                return new SavedState[size];
+            }
+        };
+        
+		private SavedState(Parcel in) {
 			super(in);
-			boolean[] showing = new boolean[1];
-			in.readBooleanArray(showing);
-			mBehindShowing = showing[0];
+			mBehindShowing = in.readByte()!=0;
 		}
-		*/
 	}
 
 	@Override
 	protected Parcelable onSaveInstanceState() {
 		Parcelable superState = super.onSaveInstanceState();
-		SavedState ss = new SavedState(superState);
-		ss.mBehindShowing = isBehindShowing();
+		SavedState ss = new SavedState(superState, isBehindShowing());
 		return ss;
 	}
 


### PR DESCRIPTION
This fixes the bug that says something like this in the crashes:

java.lang.RuntimeException: Unable to start activity ComponentInfo{com.levelup.touiteur/com.levelup.touiteur.TouiteurMain}: java.lang.IllegalArgumentException: Wrong state class, expecting View State but received class android.view.View$BaseSavedState instead. This usually happens when two views of different type have the same id in the same hierarchy. This view's id is id/blahblah. Make sure other views do not use the same id.
