### PR TITLE
Correct visibility.

### DIFF
--- a/library/src/com/slidingmenu/lib/app/SlidingActivity.java
+++ b/library/src/com/slidingmenu/lib/app/SlidingActivity.java
@@ -32,9 +32,9 @@ public class SlidingActivity extends Activity implements SlidingActivityBase {
 			return v;
 		return mHelper.findViewById(id);
 	}
-	
+
 	@Override
-	public void onSaveInstanceState(Bundle outState) {
+	protected void onSaveInstanceState(Bundle outState) {
 		super.onSaveInstanceState(outState);
 		mHelper.onSaveInstanceState(outState);
 	}

--- a/library/src/com/slidingmenu/lib/app/SlidingFragmentActivity.java
+++ b/library/src/com/slidingmenu/lib/app/SlidingFragmentActivity.java
@@ -34,7 +34,7 @@ public class SlidingFragmentActivity extends SherlockFragmentActivity implements
 	}
 
 	@Override
-	public void onSaveInstanceState(Bundle outState) {
+	protected void onSaveInstanceState(Bundle outState) {
 		super.onSaveInstanceState(outState);
 		mHelper.onSaveInstanceState(outState);
 	}

--- a/library/src/com/slidingmenu/lib/app/SlidingListActivity.java
+++ b/library/src/com/slidingmenu/lib/app/SlidingListActivity.java
@@ -38,7 +38,7 @@ public class SlidingListActivity extends ListActivity implements SlidingActivity
 	}
 
 	@Override
-	public void onSaveInstanceState(Bundle outState) {
+	protected void onSaveInstanceState(Bundle outState) {
 		super.onSaveInstanceState(outState);
 		mHelper.onSaveInstanceState(outState);
 	}

--- a/library/src/com/slidingmenu/lib/app/SlidingMapActivity.java
+++ b/library/src/com/slidingmenu/lib/app/SlidingMapActivity.java
@@ -35,7 +35,7 @@ public abstract class SlidingMapActivity extends MapActivity {
 	}
 
 	@Override
-	public void onSaveInstanceState(Bundle outState) {
+	protected void onSaveInstanceState(Bundle outState) {
 		super.onSaveInstanceState(outState);
 		mHelper.onSaveInstanceState(outState);
 	}


### PR DESCRIPTION
On these overridden framework methods, the visibility is widened from `protected` to `public`.  When we subclass the SlidingMenu Activities, our subclasses won't compile because they override using the same visibility defined by the framework, which is more narrow than SlidingMenu now has them.

There are many more framework methods (`onCreate`, etc.) than this first commit addresses, but I want to see if the SlidingMenu project is willing to accept more commits that correct these overridden method declarations before I go about making changes, especially since I don't use the other framework classes.
