### PR TITLE
Rename misspelled class

### DIFF
--- a/library/src/com/slidingmenu/lib/CanvasTransformerBuilder.java
+++ b/library/src/com/slidingmenu/lib/CanvasTransformerBuilder.java
@@ -5,7 +5,7 @@ import android.view.animation.Interpolator;
 
 import com.slidingmenu.lib.SlidingMenu.CanvasTransformer;
 
-public class CanvasTranformerBuilder {
+public class CanvasTransformerBuilder {
 
 	private CanvasTransformer mTrans;
 


### PR DESCRIPTION
There was a misspelled class. The build still compiles successfully after renaming. 
