### PR TITLE
implemented SlidingPreferenceActivity

### DIFF
--- a/library/src/com/slidingmenu/lib/app/SlidingPreferenceActivity.java
+++ b/library/src/com/slidingmenu/lib/app/SlidingPreferenceActivity.java
@@ -1,7 +1,144 @@
 package com.slidingmenu.lib.app;
 
+import com.slidingmenu.lib.SlidingMenu;
+
+import android.os.Bundle;
 import android.preference.PreferenceActivity;
+import android.view.KeyEvent;
+import android.view.View;
+import android.view.ViewGroup.LayoutParams;
 
-public class SlidingPreferenceActivity extends PreferenceActivity {
+public class SlidingPreferenceActivity extends PreferenceActivity implements SlidingActivityBase {
 
+	private SlidingActivityHelper mHelper;
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#onCreate(android.os.Bundle)
+	 */
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		mHelper = new SlidingActivityHelper(this);
+		super.onCreate(savedInstanceState);
+		mHelper.onCreate(savedInstanceState);
+	}
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#onPostCreate(android.os.Bundle)
+	 */
+	@Override
+	public void onPostCreate(Bundle savedInstanceState) {
+		super.onPostCreate(savedInstanceState);
+		mHelper.onPostCreate(savedInstanceState);
+	}
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#findViewById(int)
+	 */
+	@Override
+	public View findViewById(int id) {
+		View v = super.findViewById(id);
+		if (v != null)
+			return v;
+		return mHelper.findViewById(id);
+	}
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#onSaveInstanceState(android.os.Bundle)
+	 */
+	@Override
+	protected void onSaveInstanceState(Bundle outState) {
+		super.onSaveInstanceState(outState);
+		mHelper.onSaveInstanceState(outState);
+	}
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#setContentView(int)
+	 */
+	@Override
+	public void setContentView(int id) {
+		setContentView(getLayoutInflater().inflate(id, null));
+	}
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#setContentView(android.view.View)
+	 */
+	@Override
+	public void setContentView(View v) {
+		setContentView(v, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+	}
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#setContentView(android.view.View, android.view.ViewGroup.LayoutParams)
+	 */
+	@Override
+	public void setContentView(View v, LayoutParams params) {
+		super.setContentView(v, params);
+		mHelper.registerAboveContentView(v, params);
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#setBehindContentView(int)
+	 */
+	public void setBehindContentView(int id) {
+		setBehindContentView(getLayoutInflater().inflate(id, null));
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#setBehindContentView(android.view.View)
+	 */
+	public void setBehindContentView(View v) {
+		setBehindContentView(v, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#setBehindContentView(android.view.View, android.view.ViewGroup.LayoutParams)
+	 */
+	public void setBehindContentView(View v, LayoutParams params) {
+		mHelper.setBehindContentView(v, params);
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#getSlidingMenu()
+	 */
+	public SlidingMenu getSlidingMenu() {
+		return mHelper.getSlidingMenu();
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#toggle()
+	 */
+	public void toggle() {
+		mHelper.toggle();
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#showAbove()
+	 */
+	public void showAbove() {
+		mHelper.showAbove();
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#showBehind()
+	 */
+	public void showBehind() {
+		mHelper.showBehind();
+	}
+
+	/* (non-Javadoc)
+	 * @see com.slidingmenu.lib.app.SlidingActivityBase#setSlidingActionBarEnabled(boolean)
+	 */
+	public void setSlidingActionBarEnabled(boolean b) {
+		mHelper.setSlidingActionBarEnabled(b);
+	}
+
+	/* (non-Javadoc)
+	 * @see android.app.Activity#onKeyUp(int, android.view.KeyEvent)
+	 */
+	@Override
+	public boolean onKeyUp(int keyCode, KeyEvent event) {
+		boolean b = mHelper.onKeyUp(keyCode, event);
+		if (b) return b;
+		return super.onKeyUp(keyCode, event);
+	}
 }


### PR DESCRIPTION
SlidingPreferenceActivity is implemented similar to other activities in SlidingMenu.
The only difference is that  
`mHelper = new SlidingActivityHelper(this);`
should be invoked before
`super.onCreate(savedInstanceState);`
because of internal Android PreferenceActivity method invokation order.

This class can also be changed to extend SherlockPreferenceActivity. 
Have tested this in my app, everything works great with ActionBarSherlock.

Refs issue #92
