### PR TITLE
correct start of drag touch interception 

### DIFF
--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -637,7 +637,7 @@ public class CustomViewAbove extends ViewGroup {
 			mLastMotionX = mInitialMotionX = MotionEventCompat.getX(ev, mActivePointerId);
 			mLastMotionY = MotionEventCompat.getY(ev, mActivePointerId);
 			if (thisTouchAllowed(ev)) {
-				mIsBeingDragged = false;
+				mIsBeingDragged = SlidingMenu.TOUCHMODE_FULLSCREEN!=mTouchMode;
 				mIsUnableToDrag = false;
 				if (isMenuOpen())
 					return true;


### PR DESCRIPTION
in my view ( next to the left margin ) in the main content I still got the DOWN event for a beginning drag but no UP/OUTSIDE - so this leads to a bug 
this patch fixes that ( I use margin mode ) - no Idea on how to handle this best in FULLSCREEN mode
