### PR TITLE
Fixing focus issue

### DIFF
--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -997,13 +997,7 @@ public class CustomViewAbove extends ViewGroup {
 				direction);
 		if (nextFocused != null && nextFocused != currentFocused) {
 			if (direction == View.FOCUS_LEFT) {
-				// If there is nothing to the left, or this is causing us to
-				// jump to the right, then what we really want to do is page left.
-				if (currentFocused != null && nextFocused.getLeft() >= currentFocused.getLeft()) {
-					handled = pageLeft();
-				} else {
 					handled = nextFocused.requestFocus();
-				}
 			} else if (direction == View.FOCUS_RIGHT) {
 				// If there is nothing to the right, or this is causing us to
 				// jump to the left, then what we really want to do is page right.

--- a/library/src/com/slidingmenu/lib/CustomViewBehind.java
+++ b/library/src/com/slidingmenu/lib/CustomViewBehind.java
@@ -343,4 +343,5 @@ public class CustomViewBehind extends ViewGroup {
 		}
 		canvas.drawRect(left, 0, right, getHeight(), mFadePaint);
 	}
+
 }

--- a/library/src/com/slidingmenu/lib/CustomViewBehind.java
+++ b/library/src/com/slidingmenu/lib/CustomViewBehind.java
@@ -343,5 +343,4 @@ public class CustomViewBehind extends ViewGroup {
 		}
 		canvas.drawRect(left, 0, right, getHeight(), mFadePaint);
 	}
-
 }


### PR DESCRIPTION
Given a layout with two fragments laid out horizontally (side by side) if you focus on the right most fragment and then move focus to the left, the sliding menu will always intercept the event.

This is due to the getLeft method returning the location of the view relative to the parent and causes an incorrect if statement tp evaluate to true, I simply removed it.
