### PR TITLE
Add/Remove Views ignored by the Touch Down Event when mode is Fullscreen

### DIFF
--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -284,7 +284,9 @@ public class CustomViewAbove extends ViewGroup {
 	}
 
 	public void addIgnoredView(View v) {
-		mIgnoredViews.add(v);
+		if (!mIgnoredViews.contains(v)) {
+			mIgnoredViews.add(v);
+		}
 	}
 
 	public void removeIgnoredView(View v) {

--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -1,11 +1,11 @@
 package com.slidingmenu.lib;
 
+import java.util.ArrayList;
+import java.util.List;
+
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
-import android.graphics.Color;
-import android.graphics.Paint;
-import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.v4.view.KeyEventCompat;
 import android.support.v4.view.MotionEventCompat;
@@ -15,7 +15,6 @@ import android.support.v4.view.ViewConfigurationCompat;
 import android.util.AttributeSet;
 import android.util.FloatMath;
 import android.util.Log;
-import android.util.TypedValue;
 import android.view.FocusFinder;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
@@ -25,7 +24,6 @@ import android.view.View;
 import android.view.ViewConfiguration;
 import android.view.ViewGroup;
 import android.view.animation.Interpolator;
-import android.widget.FrameLayout;
 import android.widget.Scroller;
 
 import com.slidingmenu.lib.SlidingMenu.OnClosedListener;
@@ -98,6 +96,8 @@ public class CustomViewAbove extends ViewGroup {
 	//	private OnOpenListener mOpenListener;
 	private OnClosedListener mClosedListener;
 	private OnOpenedListener mOpenedListener;
+
+	private List<View> mIgnoredViews = new ArrayList<View>();
 
 	//	private int mScrollState = SCROLL_STATE_IDLE;
 
@@ -283,6 +283,18 @@ public class CustomViewAbove extends ViewGroup {
 		return oldListener;
 	}
 
+	public void addIgnoredView(View v) {
+		mIgnoredViews.add(v);
+	}
+
+	public void removeIgnoredView(View v) {
+		mIgnoredViews.remove(v);
+	}
+
+	public void clearIgnoredViews() {
+		mIgnoredViews.clear();
+	}
+
 	// We want the duration of the page snap animation to be influenced by the distance that
 	// the screen has to travel, however, we don't want this duration to be effected in a
 	// purely linear fashion. Instead, we use this method to moderate the effect that the distance
@@ -318,6 +330,18 @@ public class CustomViewAbove extends ViewGroup {
 
 	public boolean isMenuOpen() {
 		return mCurItem == 0 || mCurItem == 2;
+	}
+
+	private boolean isInIgnoredView(MotionEvent ev) {
+		for (View v : mIgnoredViews) {
+			if (v.getLeft() < ev.getX() &&
+					ev.getX() < v.getRight() &&
+					v.getTop() < ev.getY() &&
+					ev.getY() < v.getBottom()) {
+				return true;
+			}
+		}
+		return false;
 	}
 
 	public int getBehindWidth() {
@@ -560,7 +584,7 @@ public class CustomViewAbove extends ViewGroup {
 		} else {
 			switch (mTouchMode) {
 			case SlidingMenu.TOUCHMODE_FULLSCREEN:
-				return true;
+				return !isInIgnoredView(ev);
 			case SlidingMenu.TOUCHMODE_NONE:
 				return false;
 			case SlidingMenu.TOUCHMODE_MARGIN:

--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -335,13 +335,10 @@ public class CustomViewAbove extends ViewGroup {
 	}
 
 	private boolean isInIgnoredView(MotionEvent ev) {
+		Rect rect = new Rect();
 		for (View v : mIgnoredViews) {
-			if (v.getLeft() < ev.getX() &&
-					ev.getX() < v.getRight() &&
-					v.getTop() < ev.getY() &&
-					ev.getY() < v.getBottom()) {
-				return true;
-			}
+			v.getHitRect(rect);
+			if (rect.contains((int)ev.getX(), (int)ev.getY())) return true;
 		}
 		return false;
 	}

--- a/library/src/com/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/slidingmenu/lib/SlidingMenu.java
@@ -18,9 +18,7 @@ import android.view.Display;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
-import android.view.Window;
 import android.view.WindowManager;
-import android.view.ViewGroup.LayoutParams;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 
@@ -773,6 +771,31 @@ public class SlidingMenu extends RelativeLayout {
 	 */
 	public void setSelectorBitmap(Bitmap b) {
 		mViewAbove.setSelectorBitmap(b);
+	}
+
+	/**
+	 * Add a View ignored by the Touch Down event when mode is Fullscreen
+	 *
+	 * @param v a view to be ignored
+	 */
+	public void addIgnoredView(View v) {
+		mViewAbove.addIgnoredView(v);
+	}
+
+	/**
+	 * Remove a View ignored by the Touch Down event when mode is Fullscreen
+	 *
+	 * @param v a view not wanted to be ignored anymore
+	 */
+	public void removeIgnoredView(View v) {
+		mViewAbove.removeIgnoredView(v);
+	}
+
+	/**
+	 * Clear the list of Views ignored by the Touch Down event when mode is Fullscreen
+	 */
+	public void clearIgnoredViews() {
+		mViewAbove.clearIgnoredViews();
 	}
 
 	/**


### PR DESCRIPTION
This change is usefull when using an HorizontScrollView, or a ViewPage, a Gallery or anything with Horizontal Scroll in your Above view, when you use the TOUCH_FULLSCREEN mode.

You just have to set menu.addIgnoredView(v) in your activity and all onInterceptTouchEvent with ACTION_DOWN will be refused by the thisTouchAllowed(ev) method when the ACTION_DOWN event occured in your specified view.

I had menu.removeIgnoredView(v) and menu.clearIgnoredView() if you want to change this setting at some point (for example when the HorizontalScrollView is on its far left).
