### PR TITLE
Reduce overdraw when using the flag SLIDING_CONTENT

### DIFF
--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -4,8 +4,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import android.content.Context;
-import android.graphics.Bitmap;
 import android.graphics.Canvas;
+import android.graphics.Paint;
 import android.graphics.Rect;
 import android.os.Build;
 import android.support.v4.view.KeyEventCompat;
@@ -29,8 +29,6 @@ import android.widget.Scroller;
 
 import com.slidingmenu.lib.SlidingMenu.OnClosedListener;
 import com.slidingmenu.lib.SlidingMenu.OnOpenedListener;
-//import com.slidingmenu.lib.SlidingMenu.OnCloseListener;
-//import com.slidingmenu.lib.SlidingMenu.OnOpenListener;
 
 public class CustomViewAbove extends ViewGroup {
 
@@ -101,6 +99,9 @@ public class CustomViewAbove extends ViewGroup {
 	private List<View> mIgnoredViews = new ArrayList<View>();
 
 	//	private int mScrollState = SCROLL_STATE_IDLE;
+	
+	private int mBackgroundColor;
+	private Paint mPaint;
 
 	/**
 	 * Callback interface for responding to changing state of the selected page.
@@ -1020,4 +1021,21 @@ public class CustomViewAbove extends ViewGroup {
 		return false;
 	}
 
+	/**
+	 * Set a solid background to the view to draw
+	 * when the menu is moving, useful for content with transparent backgrounds. 
+	 * @param color The color to draw when moving the menu
+	 */
+	public void setDrawBackground(int color){
+		this.mBackgroundColor = color;
+		mPaint = new Paint();
+	}
+
+	protected void onDraw(Canvas canvas) {
+		if( (mScrolling||mIsBeingDragged||getCurrentItem()==0) 
+				&& mBackgroundColor!=0 && mPaint!=null ){
+			mPaint.setColor(mBackgroundColor);
+			canvas.drawRect(0, 0, getWidth(), getHeight(), mPaint);
+		}
+	}
 }

--- a/library/src/com/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/slidingmenu/lib/SlidingMenu.java
@@ -300,6 +300,7 @@ public class SlidingMenu extends RelativeLayout {
 		// get the window background
 		TypedArray a = activity.getTheme().obtainStyledAttributes(new int[] {android.R.attr.windowBackground});
 		int background = a.getResourceId(0, 0);
+		int backgroundColor = a.getColor(0, 0);
 		a.recycle();
 
 		switch (slideStyle) {
@@ -316,14 +317,14 @@ public class SlidingMenu extends RelativeLayout {
 		case SLIDING_CONTENT:
 			mActionbarOverlay = actionbarOverlay;
 			// take the above view out of
-			ViewGroup contentParent = (ViewGroup)activity.findViewById(android.R.id.content);
-			View content = contentParent.getChildAt(0);
+			View content = activity.findViewById(android.R.id.content);
+			ViewGroup contentParent = (ViewGroup) content.getParent();
 			contentParent.removeView(content);
-			contentParent.addView(this, 0, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+			contentParent.addView(this, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
 			setContent(content);
 			// save people from having transparent backgrounds
 			if (content.getBackground() == null)
-				content.setBackgroundResource(background);
+				mViewAbove.setDrawBackground(backgroundColor);
 			break;
 		}
 	}


### PR DESCRIPTION
When the method attachToActivity is called, currently if the content view has no background, it copies the background of the Window and results in overdraw. 

If the windows background is a color, the proposed changes will copy the color and only draw the background when the menu is sliding in / out. This results in no overdraw and speeds things up.

Currently the fix is only in place when the flag SLIDING_CONTENT is used.
