### PR TITLE
added OnStartDragListener

### DIFF
--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -30,6 +30,7 @@ import com.slidingmenu.lib.SlidingMenu.OnClosedListener;
 import com.slidingmenu.lib.SlidingMenu.OnOpenedListener;
 //import com.slidingmenu.lib.SlidingMenu.OnCloseListener;
 //import com.slidingmenu.lib.SlidingMenu.OnOpenListener;
+import com.slidingmenu.lib.SlidingMenu.OnStartDragListener;
 
 public class CustomViewAbove extends ViewGroup {
 
@@ -96,6 +97,7 @@ public class CustomViewAbove extends ViewGroup {
 	//	private OnOpenListener mOpenListener;
 	private OnClosedListener mClosedListener;
 	private OnOpenedListener mOpenedListener;
+	private OnStartDragListener mStartDragListener;
 
 	private List<View> mIgnoredViews = new ArrayList<View>();
 
@@ -265,6 +267,9 @@ public class CustomViewAbove extends ViewGroup {
 
 	public void setOnClosedListener(OnClosedListener l) {
 		mClosedListener = l;
+	}
+	public void setOnStartDragListener(OnStartDragListener l) {
+		mStartDragListener = l;
 	}
 
 	/**
@@ -868,6 +873,9 @@ public class CustomViewAbove extends ViewGroup {
 	private void startDrag() {
 		mIsBeingDragged = true;
 		mQuickReturn = false;
+
+		if (mStartDragListener != null)
+			mStartDragListener.onStartDrag(isMenuOpen());
 	}
 
 	private void endDrag() {

--- a/library/src/com/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/slidingmenu/lib/SlidingMenu.java
@@ -72,12 +72,33 @@ public class SlidingMenu extends RelativeLayout {
 
 	private OnCloseListener mCloseListener;
 
+	
+	/**
+	 * The listener interface for receiving onStartDrag events.
+	 * The class that is interested in processing a onStartDrag
+	 * event implements this interface, and the object created
+	 * with that class is registered with a component using the
+	 * component's <code>setOnStartDragListener<code> method. When
+	 * the onStartDrag event occurs, that object's appropriate
+	 * method is invoked
+	 */
+	public interface OnStartDragListener {
+
+		/**
+		 * On StartDrag.
+		 * 
+		 * @param isMenuShowing indicates if the menu was visible when the onStartDrag event occurred
+		 */
+		public void onStartDrag( boolean isMenuShowing );
+	}
+
+	
 	/**
 	 * The listener interface for receiving onOpen events.
 	 * The class that is interested in processing a onOpen
 	 * event implements this interface, and the object created
 	 * with that class is registered with a component using the
-	 * component's <code>addOnOpenListener<code> method. When
+	 * component's <code>setOnOpenListener<code> method. When
 	 * the onOpen event occurs, that object's appropriate
 	 * method is invoked
 	 */
@@ -94,7 +115,7 @@ public class SlidingMenu extends RelativeLayout {
 	 * The class that is interested in processing a onOpened
 	 * event implements this interface, and the object created
 	 * with that class is registered with a component using the
-	 * component's <code>addOnOpenedListener<code> method. When
+	 * component's <code>setOnOpenedListener<code> method. When
 	 * the onOpened event occurs, that object's appropriate
 	 * method is invoked.
 	 *
@@ -113,7 +134,7 @@ public class SlidingMenu extends RelativeLayout {
 	 * The class that is interested in processing a onClose
 	 * event implements this interface, and the object created
 	 * with that class is registered with a component using the
-	 * component's <code>addOnCloseListener<code> method. When
+	 * component's <code>setOnCloseListener<code> method. When
 	 * the onClose event occurs, that object's appropriate
 	 * method is invoked.
 	 *
@@ -132,7 +153,7 @@ public class SlidingMenu extends RelativeLayout {
 	 * The class that is interested in processing a onClosed
 	 * event implements this interface, and the object created
 	 * with that class is registered with a component using the
-	 * component's <code>addOnClosedListener<code> method. When
+	 * component's <code>setOnClosedListener<code> method. When
 	 * the onClosed event occurs, that object's appropriate
 	 * method is invoked.
 	 *
@@ -889,6 +910,16 @@ public class SlidingMenu extends RelativeLayout {
 	public void setOnClosedListener(OnClosedListener listener) {
 		mViewAbove.setOnClosedListener(listener);
 	}
+	
+	/**
+	 * Sets the OnStartDragListener. {@link OnStartDragListener#onStartDrag(boolean) OnStartDragListener.onStartDrag(boolean)} will be called when the user starts to drag the SlidingMenu
+	 *
+	 * @param listener the new OnOpenListener
+	 */
+	public void setOnStartDragListener(OnStartDragListener listener) {
+		mViewAbove.setOnStartDragListener(listener);
+	}
+
 
 	public static class SavedState extends BaseSavedState {
 


### PR DESCRIPTION
Hi,

in my project I needed to know not only that the menu is opening, opened, closing or closed, but when the user starts dragging the menu (to open it or to close it ). So I've created `OnStartDragListener` which calls `onStartDrag(boolean isMenuShowing)`. I thought that it could be usefull for others.

I've also made a small correction in javadocs.
