### PR TITLE
Reduce overdrawing by removing the window background

### DIFF
--- a/library/src/com/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/slidingmenu/lib/SlidingMenu.java
@@ -313,6 +313,8 @@ public class SlidingMenu extends RelativeLayout {
 			ViewGroup decorChild = (ViewGroup) decor.getChildAt(0);
 			// save ActionBar themes that have transparent assets
 			decorChild.setBackgroundResource(background);
+			decor.setBackgroundResource(0);
+			setBackgroundResource(0);
 			decor.removeView(decorChild);
 			decor.addView(this);
 			setContent(decorChild);


### PR DESCRIPTION
After reading the following article I had a look on the SlidingMenu and saw that the menu and the content had heavy overdrawing.
http://www.curious-creature.org/docs/android-performance-case-study-1.html
I searched through the code and could remove the overdrawing in the content by removing the window background. Unfortunately I didn't find a solution for the menu!
