### PR TITLE
Enable menu toggle when sliding is disabled

### DIFF
--- a/library/src/com/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/slidingmenu/lib/CustomViewAbove.java
@@ -803,8 +803,7 @@ public class CustomViewAbove extends ViewGroup {
 	public void scrollTo(int x, int y) {
 		super.scrollTo(x, y);
 		mScrollX = x;
-		if (mEnabled)
-			mViewBehind.scrollBehindTo(mContent, x, y);	
+		mViewBehind.scrollBehindTo(mContent, x, y);	
 		((SlidingMenu)getParent()).manageLayers(getPercentOpen());
 	}
 


### PR DESCRIPTION
mEnabled is used to check if mContent receives dragging events, it shoud not be used to stop actions. 
If mEnabled is checked in scrollTo(int,int) method, side menu can still be called out by SlidingMenu.showMenu(), but the left menu would be blank.
I got a MapFragment as content, dragging in map should move the map, instead of calling out menu. This commit fixed my problem.
