### PR TITLE
POM Updates required by Sonatype for Preparation for Sonatype Push

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.sonatype.oss</groupId>
+		<artifactId>oss-parent</artifactId>
+		<version>7</version>
+	</parent>
 
 	<groupId>com.jeremyfeinstein.slidingmenu</groupId>
 	<artifactId>parent</artifactId>
@@ -22,6 +26,7 @@
 	<scm>
 		<url>https://github.com/jfeinstein10/SlidingMenu</url>
 		<connection>scm:git:git://github.com/jfeinstein10/SlidingMenu.git</connection>
+		<developerConnection>scm:git:git@github.com:jfeinstein10/SlidingMenu.git</developerConnection>
 	</scm>
 
 	<developers>

--- a/pom.xml
+++ b/pom.xml
@@ -3,15 +3,47 @@
 	         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
+
 	<groupId>com.jeremyfeinstein.slidingmenu</groupId>
 	<artifactId>parent</artifactId>
-	<version>1.3-SNAPSHOT</version>
 	<packaging>pom</packaging>
+	<version>1.3-SNAPSHOT</version>
+
+	<name>SlidingMenu (Parent)</name>
+	<description>SlidingMenu is an Open Source Android library that allows developers to easily create applications with sliding menus like those made popular in the Google+, YouTube, and Facebook apps.</description>
+	<url>https://github.com/jfeinstein10/SlidingMenu</url>
+	<inceptionYear>2012</inceptionYear>
 
 	<modules>
 		<module>library</module>
 		<module>library-maps-support</module>
 	</modules>
+
+	<scm>
+		<url>https://github.com/jfeinstein10/SlidingMenu</url>
+		<connection>scm:git:git://github.com/jfeinstein10/SlidingMenu.git</connection>
+	</scm>
+
+	<developers>
+	  <developer>
+	    <name>Jeremy Feinstein</name>
+	    <email>jfeinstein10@gmail.com</email>
+	    <id>jfeinstein10</id>
+	    <url>http://jeremyfeinstein.com</url>
+	    <timezone>-5</timezone>
+	    <roles>
+	      <role>developer</role>
+	    </roles>
+	  </developer>
+	</developers>
+
+	<licenses>
+	  <license>
+	    <name>Apache License Version 2.0</name>
+	    <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+	    <distribution>repo</distribution>
+	  </license>
+	</licenses>
 
 	<dependencyManagement>
 		<dependencies>


### PR DESCRIPTION
These changes are required as per the {Sonatype OSS Docs](https://docs.sonatype.org/display/Repository/Sonatype+OSS+Maven+Repository+Usage+Guide) for deploying to Maven Central via Sonatype. Once merged we can start the process to get the library into Maven Central! Wooo!
