### PR TITLE
Better handling for setCurrentItem before layout has happened

### DIFF
--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
@@ -670,7 +670,7 @@ public class CustomViewAbove extends ViewGroup {
 		if (!mEnabled)
 			return false;
 
-		if (!mIsBeingDragged && !thisTouchAllowed(ev))
+		if (!mIsBeingDragged && !mQuickReturn && !thisTouchAllowed(ev))
 			return false;
 
 		//		if (!mIsBeingDragged && !mQuickReturn)
@@ -743,19 +743,18 @@ public class CustomViewAbove extends ViewGroup {
 					setCurrentItemInternal(mCurItem, true, true, initialVelocity);
 				}
 				mActivePointerId = INVALID_POINTER;
-				endDrag();
 			} else if (mQuickReturn && mViewBehind.menuTouchInQuickReturn(mContent, mCurItem, ev.getX() + mScrollX)) {
 				// close the menu
 				setCurrentItem(1);
-				endDrag();
 			}
+			endDrag();
 			break;
 		case MotionEvent.ACTION_CANCEL:
 			if (mIsBeingDragged) {
 				setCurrentItemInternal(mCurItem, true, true);
 				mActivePointerId = INVALID_POINTER;
-				endDrag();
 			}
+			endDrag();
 			break;
 		case MotionEventCompat.ACTION_POINTER_DOWN: {
 			final int indexx = MotionEventCompat.getActionIndex(ev);

--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
@@ -29,7 +29,7 @@ import android.widget.RelativeLayout;
 
 import com.jeremyfeinstein.slidingmenu.lib.CustomViewAbove.OnPageChangeListener;
 
-public class SlidingMenu extends RelativeLayout {
+public class SlidingMenu extends FrameLayout {
 
 	private static final String TAG = "SlidingMenu";
 
@@ -349,7 +349,6 @@ public class SlidingMenu extends RelativeLayout {
 	 */
 	public void setContent(View view) {
 		mViewAbove.setContent(view);
-		showContent();
 	}
 
 	/**

--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/app/SlidingActivityHelper.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/app/SlidingActivityHelper.java
@@ -61,28 +61,21 @@ public class SlidingActivityHelper {
 		mSlidingMenu.attachToActivity(mActivity, 
 				mEnableSlide ? SlidingMenu.SLIDING_WINDOW : SlidingMenu.SLIDING_CONTENT);
 		
-		final boolean open;
-		final boolean secondary;
 		if (savedInstanceState != null) {
-			open = savedInstanceState.getBoolean("SlidingActivityHelper.open");
-			secondary = savedInstanceState.getBoolean("SlidingActivityHelper.secondary");
+			boolean open = savedInstanceState.getBoolean("SlidingActivityHelper.open");
+			boolean secondary = savedInstanceState.getBoolean("SlidingActivityHelper.secondary");
+      if (open) {
+        if (secondary) {
+          mSlidingMenu.showSecondaryMenu(false);
+        } else {
+          mSlidingMenu.showMenu(false);
+        }
+      } else {
+        mSlidingMenu.showContent(false);          
+      }
 		} else {
-			open = false;
-			secondary = false;
+		  mSlidingMenu.showContent(false);
 		}
-		new Handler().post(new Runnable() {
-			public void run() {
-				if (open) {
-					if (secondary) {
-						mSlidingMenu.showSecondaryMenu(false);
-					} else {
-						mSlidingMenu.showMenu(false);
-					}
-				} else {
-					mSlidingMenu.showContent(false);					
-				}
-			}
-		});
 	}
 
 	/**


### PR DESCRIPTION
Scrolling is deferred until layout has been performed. This avoids the use of a Handler.post() in onPostCreate(), which means that additional show*() calls performed by a sub-class of SlidingActivity in onPostCreate() work as expected.

Also derive SlidingMenu from FrameLayout instead of RelativeLayout as there seems to be no reason to use RelativeLayout.
