### PR TITLE
Update to android-maven-plugin 3.6.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
 				<plugin>
 					<groupId>com.jayway.maven.plugins.android.generation2</groupId>
 					<artifactId>android-maven-plugin</artifactId>
-					<version>3.5.0</version>
+					<version>3.6.0</version>
 
 					<configuration>
 						<sdk>


### PR DESCRIPTION
Not sure if the code has been updated already or not, but need to use 3.6.0 of the android-maven-plugin to work with the latest Android SDK.
