### PR TITLE
Add a 'setAddBackground' method to SlidingMenu to let us avoid the autom...

### DIFF
--- a/example/res/layout/properties.xml
+++ b/example/res/layout/properties.xml
@@ -202,6 +202,26 @@
             android:id="@+id/fade_degree"
             android:layout_width="match_parent"
             android:layout_height="wrap_content" />
+
+        <LinearLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content" >
+
+            <TextView
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center_vertical"
+                android:layout_weight="1"
+                android:text="Add Background"
+                android:textAppearance="?android:attr/textAppearanceMedium" />
+
+            <CheckBox
+                android:id="@+id/add_background_enabled"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Enabled?" />
+        </LinearLayout>
+
     </LinearLayout>
 
 </ScrollView>

--- a/example/src/com/jeremyfeinstein/slidingmenu/example/PropertiesActivity.java
+++ b/example/src/com/jeremyfeinstein/slidingmenu/example/PropertiesActivity.java
@@ -164,6 +164,15 @@ public class PropertiesActivity extends BaseActivity {
 				getSlidingMenu().setFadeDegree((float) seekBar.getProgress()/seekBar.getMax());
 			}			
 		});
+		
+		CheckBox addBackgroundEnabled = (CheckBox) findViewById(R.id.add_background_enabled);
+		addBackgroundEnabled.setChecked(true);
+		addBackgroundEnabled.setOnCheckedChangeListener(new CompoundButton.OnCheckedChangeListener() {
+			@Override
+			public void onCheckedChanged(CompoundButton buttonView, boolean isChecked) {
+				getSlidingMenu().setAddBackground(isChecked);
+			}			
+		});
 	}
 
 }

--- a/example/src/com/jeremyfeinstein/slidingmenu/example/fragments/ColorMenuFragment.java
+++ b/example/src/com/jeremyfeinstein/slidingmenu/example/fragments/ColorMenuFragment.java
@@ -15,7 +15,9 @@ public class ColorMenuFragment extends ListFragment {
 
 	@Override
 	public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
-		return inflater.inflate(R.layout.list, null);
+		View view =inflater.inflate(R.layout.list, null);
+		view.setBackgroundColor(getResources().getColor(android.R.color.white));
+		return view;
 	}
 
 	@Override

--- a/example/src/com/jeremyfeinstein/slidingmenu/example/fragments/FragmentChangeActivity.java
+++ b/example/src/com/jeremyfeinstein/slidingmenu/example/fragments/FragmentChangeActivity.java
@@ -40,6 +40,9 @@ public class FragmentChangeActivity extends BaseActivity {
 		
 		// customize the SlidingMenu
 		getSlidingMenu().setTouchModeAbove(SlidingMenu.TOUCHMODE_FULLSCREEN);
+		getSlidingMenu().setFadeEnabled(false);
+		getSlidingMenu().setAddBackground(false);
+		getWindow().setBackgroundDrawable(null);
 	}
 	
 	@Override

--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
@@ -36,6 +36,9 @@ public class SlidingMenu extends RelativeLayout {
 	public static final int SLIDING_WINDOW = 0;
 	public static final int SLIDING_CONTENT = 1;
 	private boolean mActionbarOverlay = false;
+	private boolean mAddBackground = true;
+	private int mBackground;
+	private View mViewForBackground;
 
 	/** Constant value for use with setTouchModeAbove(). Allows the SlidingMenu to be opened with a swipe
 	 * gesture on the screen's margin
@@ -308,7 +311,7 @@ public class SlidingMenu extends RelativeLayout {
 
 		// get the window background
 		TypedArray a = activity.getTheme().obtainStyledAttributes(new int[] {android.R.attr.windowBackground});
-		int background = a.getResourceId(0, 0);
+		mBackground = a.getResourceId(0, 0);
 		a.recycle();
 
 		switch (slideStyle) {
@@ -317,7 +320,9 @@ public class SlidingMenu extends RelativeLayout {
 			ViewGroup decor = (ViewGroup) activity.getWindow().getDecorView();
 			ViewGroup decorChild = (ViewGroup) decor.getChildAt(0);
 			// save ActionBar themes that have transparent assets
-			decorChild.setBackgroundResource(background);
+			mViewForBackground = decorChild;
+			if (mAddBackground)
+			    decorChild.setBackgroundResource(mBackground);
 			decor.removeView(decorChild);
 			decor.addView(this);
 			setContent(decorChild);
@@ -327,12 +332,13 @@ public class SlidingMenu extends RelativeLayout {
 			// take the above view out of
 			ViewGroup contentParent = (ViewGroup)activity.findViewById(android.R.id.content);
 			View content = contentParent.getChildAt(0);
+			mViewForBackground = content;
 			contentParent.removeView(content);
 			contentParent.addView(this);
 			setContent(content);
 			// save people from having transparent backgrounds
-			if (content.getBackground() == null)
-				content.setBackgroundResource(background);
+			if (mAddBackground)
+				content.setBackgroundResource(mBackground);
 			break;
 		}
 	}
@@ -793,6 +799,23 @@ public class SlidingMenu extends RelativeLayout {
 		mViewBehind.setShadowWidth(pixels);
 	}
 
+	/**
+	 * Sets whether the window background should be set as the background behind the content.
+	 * If false then the content view needs to have its own background set.
+	 * @param b true to automatically set the background, false to set none
+	 */
+	public void setAddBackground(boolean b) {
+		if (b != mAddBackground) {
+			if (null != mViewForBackground) {
+			    if (b) {
+				    mViewForBackground.setBackgroundResource(mBackground);
+			    } else {
+				    mViewForBackground.setBackground(null);
+			    }
+			}
+			mAddBackground = b;
+		}
+	}
 	/**
 	 * Enables or disables the SlidingMenu's fade in and out
 	 *


### PR DESCRIPTION
...atic addition of the window's background behind the content view. This lets us avoid overdraw, which should make redraw faster.

The changes in https://github.com/jfeinstein10/SlidingMenu/pull/294 didn't really work for me. I think it's important that the current behaviour, i.e. you don't need to explicitly set a background on the content view or the menu view, is the default as it makes the library easier to use. But if you want to remove unnecessary overdraw I don't see any alternative other than setting the window background to null, and if you do that then you obviously need to have the content/menu views have their own backgrounds.

I've tweaked the Changing Fragments example to show how the new method would work, and this eliminates the unnecessary overdraw for this case.
