### PR TITLE
Avoid touch lockup due to mQuickReturn == true

### DIFF
--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
@@ -670,7 +670,7 @@ public class CustomViewAbove extends ViewGroup {
 		if (!mEnabled)
 			return false;
 
-		if (!mIsBeingDragged && !thisTouchAllowed(ev))
+		if (!mIsBeingDragged && !mQuickReturn && !thisTouchAllowed(ev))
 			return false;
 
 		//		if (!mIsBeingDragged && !mQuickReturn)
@@ -743,19 +743,18 @@ public class CustomViewAbove extends ViewGroup {
 					setCurrentItemInternal(mCurItem, true, true, initialVelocity);
 				}
 				mActivePointerId = INVALID_POINTER;
-				endDrag();
 			} else if (mQuickReturn && mViewBehind.menuTouchInQuickReturn(mContent, mCurItem, ev.getX() + mScrollX)) {
 				// close the menu
 				setCurrentItem(1);
-				endDrag();
 			}
+			endDrag();
 			break;
 		case MotionEvent.ACTION_CANCEL:
 			if (mIsBeingDragged) {
 				setCurrentItemInternal(mCurItem, true, true);
 				mActivePointerId = INVALID_POINTER;
-				endDrag();
 			}
+			endDrag();
 			break;
 		case MotionEventCompat.ACTION_POINTER_DOWN: {
 			final int indexx = MotionEventCompat.getActionIndex(ev);


### PR DESCRIPTION
This can happen when a DOWN event is triggered in the quickreturn area, and the finger then moved out of that area without triggering a drag (e.g. by moving vertically first and then across). If the menu is then closed in some other way (e.g. back key) the CustomViewAbove remains in mQuickReturn == true state and blocks all touches to the main content, making the app appear unresponsive or crashed to the user.
