### PR TITLE
Fix Copyright Year

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,7 @@ Developed By
 License
 -------
 
-    Copyright 2012 Jeremy Feinstein
+    Copyright 2012-2014 Jeremy Feinstein
     
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
Fix outdated copyright year (update to 2014)
The copyright year was out of date. Copyright notices must reflect the current year. This commit updates the listed year to 2014.

see: http://www.copyright.gov/circs/circ01.pdf for more info
