### PR TITLE
Remove MLS MatchDay from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,6 @@ SlidingMenu is currently used in some awesome Android apps. Here's a list of som
 * [Plume][4]
 * [VLC for Android][5]
 * [ESPN ScoreCenter][14]
-* [MLS MatchDay][16]
 * [9GAG][17]
 * [Wunderlist 2][13]
 * [The Verge][6]
@@ -179,7 +178,6 @@ License
 [13]: http://bit.ly/xs1sMN
 [14]: https://play.google.com/store/apps/details?id=com.espn.score_center
 [15]: https://play.google.com/store/apps/details?id=com.joelapenna.foursquared
-[16]: https://play.google.com/store/apps/details?id=com.mlssoccer
 [17]: https://play.google.com/store/apps/details?id=com.ninegag.android.app
 [18]: https://play.google.com/store/apps/details?id=com.evernote.food
 [19]: https://play.google.com/store/apps/details?id=com.linkedin.android


### PR DESCRIPTION
I have it on good authority that MLS MatchDay is no longer using SlidingMenu
