### PR TITLE
#692 backstack changes listening

### DIFF
--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/CustomViewAbove.java
@@ -300,7 +300,7 @@ public class CustomViewAbove extends ViewGroup {
 	float distanceInfluenceForSnapDuration(float f) {
 		f -= 0.5f; // center the values about 0.
 		f *= 0.3f * Math.PI / 2.0f;
-		return (float) FloatMath.sin(f);
+		return (float) Math.sin(f);
 	}
 
 	public int getDestScrollX(int page) {

--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/OnFragmentChangeListener.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/OnFragmentChangeListener.java
@@ -1,0 +1,7 @@
+package com.jeremyfeinstein.slidingmenu.lib;
+
+public interface OnFragmentChangeListener {
+	
+	void onFragmentChanged();
+
+}

--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
@@ -17,7 +17,6 @@ import android.graphics.Point;
 import android.graphics.Rect;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
-import android.os.Handler;
 import android.os.Parcel;
 import android.os.Parcelable;
 import android.support.v4.app.FragmentActivity;

--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
@@ -933,7 +933,7 @@ public class SlidingMenu extends RelativeLayout {
 	 * Add listener for fragment back stack changes
 	 * @param listener - Listener that will respond on fragment back stack change.
 	 */
-	public void addOnFragmentChangedListener(OnFragmentChangeListener listener) {
+	public void addOnFragmentChangedListener(OnFragmentChangeListener listener) throws IllegalArgumentException {
 		Context context = getContext();
 		
 		if(!(context instanceof Activity)){

--- a/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
+++ b/library/src/com/jeremyfeinstein/slidingmenu/lib/SlidingMenu.java
@@ -1,6 +1,7 @@
 package com.jeremyfeinstein.slidingmenu.lib;
 
 import java.lang.reflect.Method;
+import java.util.HashSet;
 
 import android.annotation.SuppressLint;
 import android.annotation.TargetApi;
@@ -36,6 +37,7 @@ public class SlidingMenu extends RelativeLayout {
 	public static final int SLIDING_WINDOW = 0;
 	public static final int SLIDING_CONTENT = 1;
 	private boolean mActionbarOverlay = false;
+	private HashSet<OnFragmentChangeListener> onFragmentChangeListeners;
 
 	/** Constant value for use with setTouchModeAbove(). Allows the SlidingMenu to be opened with a swipe
 	 * gesture on the screen's margin
@@ -921,6 +923,26 @@ public class SlidingMenu extends RelativeLayout {
 	public void setOnClosedListener(OnClosedListener listener) {
 		mViewAbove.setOnClosedListener(listener);
 	}
+	
+	/**
+	 * Add listener for fragment back stack changes
+	 * @param listener - Listener that will respond on fragment back stack change.
+	 */
+	public void addOnFragmentChangedListener(OnFragmentChangeListener listener) {
+		if(onFragmentChangeListeners == null){
+			onFragmentChangeListeners = new HashSet<OnFragmentChangeListener>();
+		}
+		
+		onFragmentChangeListeners.add(listener);
+	}
+	
+	/**
+	 * Remove listener for fragment back stack changes
+	 * @param listener - Listener that will be removed.
+	 */
+	public void removeOnFragmentChangedListener(OnFragmentChangeListener listener){
+		onFragmentChangeListeners.remove(listener);
+	}
 
 	public static class SavedState extends BaseSavedState {
 
@@ -960,7 +982,7 @@ public class SlidingMenu extends RelativeLayout {
 		};
 
 	}
-
+	
 	/* (non-Javadoc)
 	 * @see android.view.View#onSaveInstanceState()
 	 */


### PR DESCRIPTION
Developers (users) are able now to subscribe SlidingMenu instance on back stack changes. So, when user navigates through fragments SlidingMenu is aware of that.

To subscribe / unsubscribe user only needs these method calls from SlidingMenu class:
- addOnFragmentChangedListener( OnFragmentChangeListener listener )
- removeOnFragmentChangedListener( OnFragmentChangeListener listener ).
